### PR TITLE
Remove the events widget from the home page

### DIFF
--- a/src/system/templates/home.html
+++ b/src/system/templates/home.html
@@ -12,11 +12,6 @@
   </div>
   <div class="col-md-6">
     {% load_contentblock 'home_part3' %}
-    <h2>Upcoming events</h2>
-    <div class="panel panel-default">
-      {% include 'home_eventpreview2.html' %}
-      <div class='eventtablefooter'>View this list on its <a href="{% url 'eventspreview' %}">own page.</a> Visit our <a href="{% url 'events' %}">Events Page</a> for the full list.</div>
-    </div>
   </div>
 </div>
 {% endblock %}

--- a/src/system/urls.py
+++ b/src/system/urls.py
@@ -10,11 +10,11 @@ from .views import home, events_preview, about_contact
 urlpatterns = [
   # Main site
   url(r'^$', home, {'event_preview_days': 14}, name='home'),
-  url(r'^events_preview/$', events_preview, {'event_preview_days': 14}, name='eventspreview'),
+  # url(r'^events_preview/$', events_preview, {'event_preview_days': 14}, name='eventspreview'),
   url(r'^about_contact/$', about_contact, name='about_contact'),
 
   # URLConfs from apps
-  url(r'^events/', include('events.urls')),
+  # url(r'^events/', include('events.urls')),
   url(r'^member/', include('clubmembers.urls')),
 
   # Django apps

--- a/src/system/views.py
+++ b/src/system/views.py
@@ -12,11 +12,12 @@ from clubmembers.models import Member
 from events.models import Event
 
 def _get_preview_of_events(event_preview_days):
-  if not event_preview_days: event_preview_days=7
-  now = timezone.now()
-  range_start = now - timedelta(days=1)
-  range_end = now + timedelta(days=event_preview_days)
-  return Event.objects.filter(start__gte=range_start, start__lte=range_end)
+  return []
+  # if not event_preview_days: event_preview_days=7
+  # now = timezone.now()
+  # range_start = now - timedelta(days=1)
+  # range_end = now + timedelta(days=event_preview_days)
+  # return Event.objects.filter(start__gte=range_start, start__lte=range_end)
 
 def home(request, event_preview_days=None):
   context = {
@@ -26,12 +27,13 @@ def home(request, event_preview_days=None):
   return render(request, "home.html", context)
 
 def events_preview(request, event_preview_days=None):
-  context = {
-    'events': _get_preview_of_events(event_preview_days),
-    'event_preview_days': event_preview_days,
-    'is_popup': True,
-  }
-  return render(request, "home_eventpreview1.html", context)
+  raise Http404()
+  # context = {
+  #   'events': _get_preview_of_events(event_preview_days),
+  #   'event_preview_days': event_preview_days,
+  #   'is_popup': True,
+  # }
+  # return render(request, "home_eventpreview1.html", context)
 
 def about_contact(request):
   if request.user.is_anonymous():


### PR DESCRIPTION
On request of @FriendComp... remove the events widget from the home page. I'm actually going to disable the /events URL entirely and some internal stuff to prevent the events from being accessed accidentally.